### PR TITLE
add cmake to our CI base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:noble-20240114 AS base
+FROM ubuntu:jammy-20240627.1 AS base
 
 RUN apt-get update && \
     apt-get install -y \

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ RUN apt-get update && \
     apt-get install -y \
         libwebkit2gtk-4.0-dev build-essential curl wget \
         libssl-dev libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev \
-        jq tar bash libbrotli-dev brotli imagemagick git
+        jq tar bash libbrotli-dev brotli imagemagick git cmake
 
 RUN curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain nightly -y
 


### PR DESCRIPTION
For some reason, `ubuntu:noble-20240114` used to have `libwebkit2gtk-4.0-dev` in the packages repository, but now it's no longer there... Therefore the switch to `jammy-20240627.1`