### PR TITLE
Add package needed by Tauri v2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:jammy-20240627.1 AS base
 
 RUN apt-get update && \
     apt-get install -y \
-        libwebkit2gtk-4.0-dev build-essential curl wget \
+        libwebkit2gtk-4.0-dev libwebkit2gtk-4.1-dev build-essential curl wget \
         libssl-dev libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev \
         jq tar bash libbrotli-dev brotli imagemagick git cmake
 


### PR DESCRIPTION
Adding this as I'm unable to test Tauri v2 upgrade in CI, missing libsoup-3.0.