### PR TITLE
Add Playwright chromium system dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,15 @@
 FROM ubuntu:jammy-20240627.1 AS base
 
+# The final block is Playwright chromium system dependencies for Ubuntu 22.04,
+# so `playwright install` in CI does not need `--with-deps`.
 RUN apt-get update && \
     apt-get install -y \
         libwebkit2gtk-4.0-dev libwebkit2gtk-4.1-dev build-essential curl wget \
         libssl-dev libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev \
-        jq tar bash libbrotli-dev brotli imagemagick git cmake
+        jq tar bash libbrotli-dev brotli imagemagick git cmake \
+        libnspr4 libnss3 libasound2 libatk-bridge2.0-0 libdrm2 \
+        libxcomposite1 libxdamage1 libxfixes3 libxrandr2 libgbm1 \
+        libxkbcommon0 libpango-1.0-0 libcairo2 libcups2
 
 RUN curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain nightly -y
 


### PR DESCRIPTION
## Summary
- Add Playwright chromium apt deps (`libnspr4`, `libnss3`, `libasound2`, and the rest of the Ubuntu 22.04 chromium list) to the base image.

## Why
The gitbutler `E2E Tests Playwright` workflow runs `pnpm exec playwright install --with-deps` on cache miss. On top of this base image that step has been observed to take **40+ minutes** (see e.g. gitbutlerapp/gitbutler#13336, job 71622403832). `libnss3` alone is what the workflow already `apt-get install`s in its cache-hit fallback step, so we know it's missing today.

With these packages baked in, the follow-up change in `gitbutlerapp/gitbutler` can drop `--with-deps` (just downloads browser binaries, ~1–2 min) and the libnss3 fallback step entirely.

Most listed packages are already pulled in transitively by `libgtk-3-dev` / `libwebkit2gtk-*-dev`; listing them explicitly guards against future Playwright bumps changing the set.

## Test plan
- [ ] PR CI builds the image successfully.
- [ ] After merge, follow-up gitbutler PR pins to the new digest and drops `--with-deps` + libnss3 fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)