### PR TITLE
Add Playwright webkit system dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 FROM ubuntu:jammy-20240627.1 AS base
 
-# The final block is Playwright chromium system dependencies for Ubuntu 22.04,
-# so `playwright install` in CI does not need `--with-deps`.
+# Playwright browser deps (chromium + webkit) and blackbox e2e packages
+# (webkit2gtk-driver, ffmpeg, xvfb), so downstream workflows don't need
+# apt-get install at runtime.
 RUN apt-get update && \
     apt-get install -y \
         libwebkit2gtk-4.0-dev libwebkit2gtk-4.1-dev build-essential curl wget \
@@ -9,7 +10,10 @@ RUN apt-get update && \
         jq tar bash libbrotli-dev brotli imagemagick git cmake \
         libnspr4 libnss3 libasound2 libatk-bridge2.0-0 libdrm2 \
         libxcomposite1 libxdamage1 libxfixes3 libxrandr2 libgbm1 \
-        libxkbcommon0 libpango-1.0-0 libcairo2 libcups2
+        libxkbcommon0 libpango-1.0-0 libcairo2 libcups2 \
+        webkit2gtk-driver ffmpeg xvfb \
+        libgtk-4-1 libevent-2.1-7 gstreamer1.0-plugins-bad \
+        libflite1 libavif13 libx264-163
 
 RUN curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain nightly -y
 


### PR DESCRIPTION
## Summary
- Add Playwright webkit system deps (`libgtk-4-1`, `libevent-2.1-7`, `gstreamer1.0-plugins-bad`, `libflite1`, `libavif13`, `libx264-163`) to the base apt layer.
- Add blackbox e2e packages (`webkit2gtk-driver`, `ffmpeg`, `xvfb`) — resolves the TODO at `test-e2e-blackbox.yml:39`.

## Why
Enabling webkit as a Playwright project in `gitbutlerapp/gitbutler` surfaced missing shared libs (`libgtk-4.so.1`, `libevent-2.1.so.7`, `libgstcodecparsers-1.0.so.0`, `libflite*`, `libavif.so.13`, `libx264.so`). The blackbox e2e workflow has been `apt update && apt install`-ing `webkit2gtk-driver ffmpeg xvfb` at runtime on every run — with a TODO to move them into the image.

## Test plan
- [ ] PR CI builds the image successfully.
- [ ] After merge, bump the `ci-base-image` digest in `gitbutlerapp/gitbutler` and confirm both e2e workflows pass without runtime `apt-get install`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)